### PR TITLE
Copy files in all installed packages

### DIFF
--- a/src/Sasedev/Composer/Plugin/Filescopier/ScriptHandler.php
+++ b/src/Sasedev/Composer/Plugin/Filescopier/ScriptHandler.php
@@ -78,10 +78,12 @@ class ScriptHandler implements PluginInterface, EventSubscriberInterface
 	public static function buildParameters(Event $event)
 	{
 
-		$installedPackages = $event->getComposer()
+      $composer = $event->getComposer();
+      $installedPackages = $composer
 			->getRepositoryManager()
 			->getLocalRepository()
 			->getCanonicalPackages();
+        $installedPackages[] = $composer->getPackage();
 		foreach ($installedPackages as $package) {
 			self::copyFiles($event, $package);
 		}


### PR DESCRIPTION
By default only files are copied that are defined in the composer.json of the project. I've changed it to move files defined in all installed packages.